### PR TITLE
feat: do not allow whitespace before commits

### DIFF
--- a/functions/src/is-message-semantic.spec.ts
+++ b/functions/src/is-message-semantic.spec.ts
@@ -201,4 +201,12 @@ describe('isMessageSemantic', () => {
 
     expect(isSemantic).toEqual(false);
   });
+
+  it('should return false if there is leading whitespace', () => {
+    const message = ' feat: change foo to bar';
+
+    const isSemantic = isMessageSemantic(defaultConfig)(message);
+
+    expect(isSemantic).toEqual(false);
+  })
 });

--- a/functions/src/is-message-semantic.spec.ts
+++ b/functions/src/is-message-semantic.spec.ts
@@ -208,5 +208,5 @@ describe('isMessageSemantic', () => {
     const isSemantic = isMessageSemantic(defaultConfig)(message);
 
     expect(isSemantic).toEqual(false);
-  })
+  });
 });

--- a/functions/src/is-message-semantic.ts
+++ b/functions/src/is-message-semantic.ts
@@ -21,12 +21,17 @@ export function isMessageSemantic({
       return true;
     }
 
+    if (message.startsWith(' ')) {
+      return false;
+    }
+
     let commit: ConventionalChangelogCommit;
     try {
       commit = toConventionalChangelogFormat(parser(message));
     } catch (err) {
       return false;
     }
+
 
     const { scope, type } = commit;
     const isScopeValid =

--- a/functions/src/is-message-semantic.ts
+++ b/functions/src/is-message-semantic.ts
@@ -32,7 +32,6 @@ export function isMessageSemantic({
       return false;
     }
 
-
     const { scope, type } = commit;
     const isScopeValid =
       !scopes ||


### PR DESCRIPTION
makes commit messages like ` feat: do foo to bar` invalid.