### PR TITLE
feat: improve messaging when both the title and every commit must be semantic

### DIFF
--- a/functions/src/handle-pull-request-change.spec.ts
+++ b/functions/src/handle-pull-request-change.spec.ts
@@ -484,7 +484,7 @@ describe('handlePullRequestChange', () => {
           'titleAndCommits: true\nanyCommit: false',
           {
             state: 'failure',
-            description: 'add a semantic commit AND PR title',
+            description: 'make sure every commit AND the PR title is semantic',
           },
         );
 
@@ -500,7 +500,7 @@ describe('handlePullRequestChange', () => {
           'titleAndCommits: true\nanyCommit: false',
           {
             state: 'failure',
-            description: 'add a semantic commit AND PR title',
+            description: 'make sure every commit AND the PR title is semantic',
           },
         );
 
@@ -516,7 +516,7 @@ describe('handlePullRequestChange', () => {
           'titleAndCommits: true\nanyCommit: false',
           {
             state: 'failure',
-            description: 'add a semantic commit AND PR title',
+            description: 'make sure every commit AND the PR title is semantic',
           },
         );
 
@@ -532,7 +532,7 @@ describe('handlePullRequestChange', () => {
           'titleAndCommits: true\nanyCommit: false',
           {
             state: 'failure',
-            description: 'add a semantic commit AND PR title',
+            description: 'make sure every commit AND the PR title is semantic',
           },
         );
 
@@ -548,7 +548,7 @@ describe('handlePullRequestChange', () => {
           'titleAndCommits: true\nanyCommit: false',
           {
             state: 'failure',
-            description: 'add a semantic commit AND PR title',
+            description: 'make sure every commit AND the PR title is semantic',
           },
         );
 

--- a/functions/src/handle-pull-request-change.ts
+++ b/functions/src/handle-pull-request-change.ts
@@ -110,7 +110,7 @@ export async function handlePullRequestChange(context: Context<ContextEvent>): P
         return new SuccessFailureSemanticState(
           hasSemanticTitle && allCommitsSemantic,
           'ready to be merged, squashed or rebased',
-          'add a semantic commit AND PR title',
+          'make sure every commit AND the PR title is semantic',
         );
       }
     } else if (numNonMergeCommits === 1) {


### PR DESCRIPTION
When every commit is required to be semantic, the PR hint should not only say "a commit".