### PR TITLE
fix: support spaces in scopes

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -34,12 +34,12 @@
   },
   "dependencies": {
     "@conventional-commits/parser": "0.4.1",
-    "@octokit/webhooks": "9.26.3",
     "conventional-commit-types": "3.0.0",
     "firebase-functions": "4.6.0",
     "probot": "12.3.3"
   },
   "devDependencies": {
+    "@octokit/webhooks": "9.26.3",
     "@octokit/webhooks-types": "7.3.1",
     "@stryker-mutator/core": "7.3.0",
     "@stryker-mutator/jest-runner": "7.3.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@conventional-commits/parser": "0.4.1",
+    "@octokit/webhooks": "9.26.3",
     "conventional-commit-types": "3.0.0",
     "firebase-functions": "4.6.0",
     "probot": "12.3.3"

--- a/functions/src/is-message-semantic.spec.ts
+++ b/functions/src/is-message-semantic.spec.ts
@@ -98,48 +98,61 @@ describe('isMessageSemantic', () => {
     expect(isSemantic).toEqual(true);
   });
 
-  it('should return true if the message is semantic and has multiple allowed scopes and the type is valid', () => {
-    const message = 'feat(auth,docs): change foo to bar';
+  describe('multiple scopes', () => {
+    it('should return true if the message is semantic and has multiple allowed scopes and the type is valid', () => {
+      const message = 'feat(auth,docs): change foo to bar';
 
-    const isSemantic = isMessageSemantic({
-      ...defaultConfig,
-      scopes: ['auth', 'docs', 'profile'],
-    })(message);
+      const isSemantic = isMessageSemantic({
+        ...defaultConfig,
+        scopes: ['auth', 'docs', 'profile'],
+      })(message);
 
-    expect(isSemantic).toEqual(true);
-  });
+      expect(isSemantic).toEqual(true);
+    });
 
-  it('should return false if the message is semantic and has a single disallowed scope and the type is valid', () => {
-    const message = 'feat(auth): change foo to bar';
+    it('should return true if the message is semantic and has multiple allowed scopes separated with spaces and the type is valid', () => {
+      const message = 'feat(auth, docs): change foo to bar';
 
-    const isSemantic = isMessageSemantic({
-      ...defaultConfig,
-      scopes: ['docs', 'profile'],
-    })(message);
+      const isSemantic = isMessageSemantic({
+        ...defaultConfig,
+        scopes: ['auth', 'docs', 'profile'],
+      })(message);
 
-    expect(isSemantic).toEqual(false);
-  });
+      expect(isSemantic).toEqual(true);
+    });
 
-  it('should return false if the message is semantic and has multiple disallowed scopes and the type is valid', () => {
-    const message = 'feat(auth,docs): change foo to bar';
+    it('should return false if the message is semantic and has a single disallowed scope and the type is valid', () => {
+      const message = 'feat(auth): change foo to bar';
 
-    const isSemantic = isMessageSemantic({
-      ...defaultConfig,
-      scopes: ['profile'],
-    })(message);
+      const isSemantic = isMessageSemantic({
+        ...defaultConfig,
+        scopes: ['docs', 'profile'],
+      })(message);
 
-    expect(isSemantic).toEqual(false);
-  });
+      expect(isSemantic).toEqual(false);
+    });
 
-  it('should return false if the message is semantic and has mix of allowed and disallowed scopes and the type is valid', () => {
-    const message = 'feat(auth,docs): change foo to bar';
+    it('should return false if the message is semantic and has multiple disallowed scopes and the type is valid', () => {
+      const message = 'feat(auth,docs): change foo to bar';
 
-    const isSemantic = isMessageSemantic({
-      ...defaultConfig,
-      scopes: ['auth', 'profile'],
-    })(message);
+      const isSemantic = isMessageSemantic({
+        ...defaultConfig,
+        scopes: ['profile'],
+      })(message);
 
-    expect(isSemantic).toEqual(false);
+      expect(isSemantic).toEqual(false);
+    });
+
+    it('should return false if the message is semantic and has mix of allowed and disallowed scopes and the type is valid', () => {
+      const message = 'feat(auth,docs): change foo to bar';
+
+      const isSemantic = isMessageSemantic({
+        ...defaultConfig,
+        scopes: ['auth', 'profile'],
+      })(message);
+
+      expect(isSemantic).toEqual(false);
+    });
   });
 
   it('should return true if no types are provided and the type is one of the default types', () => {

--- a/functions/src/is-message-semantic.ts
+++ b/functions/src/is-message-semantic.ts
@@ -33,7 +33,13 @@ export function isMessageSemantic({
     }
 
     const { scope, type } = commit;
-    const isScopeValid = !scopes || !scope || scope.split(',').every(scope => scopes.includes(scope));
+    const isScopeValid =
+      !scopes ||
+      !scope ||
+      scope
+        .split(',')
+        .map(scope => scope.trim())
+        .every(scope => scopes.includes(scope));
     const isTypeValid = (types.length > 0 ? types : commitTypes).includes(type);
     return isTypeValid && isScopeValid;
   };


### PR DESCRIPTION
## Summary

- fixes #478

## Description

- trimed `,` delimited scopes before checking.

## Others

- added  `@octokit/webhooks` to package.json to fix build failure
- added and grouped related tests.
