### PR TITLE
feat: support regex scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,18 @@ types: # default: feat | fix | docs | style | refactor | perf | test | build | c
 
 ```yaml
 # The values allowed for the "scope" part of the PR title/commit message. e.g. for a PR title/commit message of "feat(awesome-feature): add some stuff", the type would be "awesome-feature"
+# Values can be exact scopes or regular expressions.
 scopes: # default: any value
   - <string>
   - <string>
   - ...
+```
+
+```yaml
+# Regular expression scopes match the full scope value.
+# For example, this matches "feat(mods/foo): ..." and "feat(mods/bar): ..."
+scopes:
+  - 'mods/(\\w+)'
 ```
 
 ```yaml

--- a/functions/src/is-message-semantic.spec.ts
+++ b/functions/src/is-message-semantic.spec.ts
@@ -109,6 +109,61 @@ describe('isMessageSemantic', () => {
     expect(isSemantic).toEqual(true);
   });
 
+  it('should return true if the message is semantic and has a scope matching an allowed regex scope', () => {
+    const message = 'feat(mods/foo): change foo to bar';
+
+    const isSemantic = isMessageSemantic({
+      ...defaultConfig,
+      scopes: ['mods/(\\w+)'],
+    })(message);
+
+    expect(isSemantic).toEqual(true);
+  });
+
+  it('should return true if the message is semantic and has a mix of allowed exact and regex scopes', () => {
+    const message = 'feat(auth,mods/foo): change foo to bar';
+
+    const isSemantic = isMessageSemantic({
+      ...defaultConfig,
+      scopes: ['auth', 'mods/(\\w+)'],
+    })(message);
+
+    expect(isSemantic).toEqual(true);
+  });
+
+  it('should return false if the message scope only partially matches an allowed regex scope', () => {
+    const message = 'feat(mods/foo/bar): change foo to bar';
+
+    const isSemantic = isMessageSemantic({
+      ...defaultConfig,
+      scopes: ['mods/(\\w+)'],
+    })(message);
+
+    expect(isSemantic).toEqual(false);
+  });
+
+  it('should return false instead of throwing if a configured regex scope is invalid', () => {
+    const message = 'feat(auth): change foo to bar';
+
+    const isSemantic = isMessageSemantic({
+      ...defaultConfig,
+      scopes: ['['],
+    })(message);
+
+    expect(isSemantic).toEqual(false);
+  });
+
+  it('should return true if the message has an exact scope matching an invalid regex scope', () => {
+    const message = 'feat([): change foo to bar';
+
+    const isSemantic = isMessageSemantic({
+      ...defaultConfig,
+      scopes: ['['],
+    })(message);
+
+    expect(isSemantic).toEqual(true);
+  });
+
   it('should return false if the message is semantic and has a single disallowed scope and the type is valid', () => {
     const message = 'feat(auth): change foo to bar';
 

--- a/functions/src/is-message-semantic.ts
+++ b/functions/src/is-message-semantic.ts
@@ -5,12 +5,33 @@ import { Config } from './config';
 const commitTypes = Object.keys(types);
 const validTypeSyntaxRegex = /^.*: [^ ].*$/;
 
+type AllowedScope = {
+  exact: string;
+  regex: RegExp | null;
+};
+
+const toScopeRegex = (scope: string): RegExp | null => {
+  try {
+    return new RegExp(`^(?:${scope})$`);
+  } catch {
+    return null;
+  }
+};
+
+const isAllowedScope = ({ exact, regex }: AllowedScope, scope: string): boolean =>
+  exact === scope || regex?.test(scope) === true;
+
 export function isMessageSemantic({
   scopes,
   types,
   allowMergeCommits,
   allowRevertCommits,
 }: Config): (message: string) => boolean {
+  const allowedScopes = scopes?.map(scope => ({
+    exact: scope,
+    regex: toScopeRegex(scope),
+  }));
+
   return function (message: string) {
     const isMergeCommit = message.startsWith('Merge');
     if (allowMergeCommits && isMergeCommit) {
@@ -34,7 +55,10 @@ export function isMessageSemantic({
     }
 
     const { scope, type } = commit;
-    const isScopeValid = !scopes || !scope || scope.split(/, ?/).every(scope => scopes.includes(scope));
+    const isScopeValid =
+      !allowedScopes ||
+      !scope ||
+      scope.split(/, ?/).every(scope => allowedScopes.some(allowedScope => isAllowedScope(allowedScope, scope)));
     const isTypeValid = (types.length > 0 ? types : commitTypes).includes(type) && validTypeSyntaxRegex.test(message);
 
     return isTypeValid && isScopeValid;


### PR DESCRIPTION
close #450
Related: #982

## Summary
- Allow configured scopes to match exact values or full-scope regex patterns.
- Ignore invalid regex patterns except for exact matches.
- Document regex scope usage.

## Testing
- `mise exec node@24.14.1 -- npm run lint:code`
- `mise exec node@24.14.1 -- npm run lint:style`
- `mise exec node@24.14.1 -- npm run build`
- `mise exec node@24.14.1 -- npm run test:unit:coverage`

<sub>PR opened by gpt-5.5 high on pi</sub>
